### PR TITLE
Testnet deployment fixes

### DIFF
--- a/tasks/deploy/2-1-deployPostLbpStack.ts
+++ b/tasks/deploy/2-1-deployPostLbpStack.ts
@@ -263,7 +263,7 @@ export async function getTapToken(params: {
                 epochDuration:
                     DEPLOY_CONFIG.FINAL[hre.SDK.eChainId]!.TOLP.EPOCH_DURATION, // Epoch duration
                 endpoint: lzEndpointAddress, // Endpoint address
-                contributors: isTestnet ? owner : '0x', //contributors address
+                contributors: isTestnet ? owner : '0x', //contributors address, we use owner for testnet
                 earlySupporters: hre.ethers.constants.AddressZero, // early supporters address
                 supporters: hre.ethers.constants.AddressZero, // supporters address
                 lTap: lTap.address, // lTap address
@@ -309,7 +309,7 @@ function getTapTokenDependencies(params: {
 
     if (isGovernanceChain) {
         // Inject multicall address as contributors if testnet
-        if (isTestnet) {
+        if (!isTestnet) {
             dependencies = [
                 ...dependencies,
                 {

--- a/tasks/deploy/3-deployFinalStack.ts
+++ b/tasks/deploy/3-deployFinalStack.ts
@@ -12,6 +12,7 @@ import { buildTolp } from '../deployBuilds/finalStack/options/buildTOLP';
 import { buildTwTap } from '../deployBuilds/finalStack/options/deployTwTap';
 import { loadVM } from '../utils';
 import { DEPLOYMENT_NAMES, DEPLOY_CONFIG } from './DEPLOY_CONFIG';
+import * as TAPIOCA_PERIPH_DEPLOY_CONFIG from '@tapioca-periph/config';
 
 export const deployFinalStack__task = async (
     taskArgs: { tag?: string; load?: boolean; verify?: boolean },
@@ -112,7 +113,7 @@ async function getContracts(
     const pearlmit = hre.SDK.db.findGlobalDeployment(
         TAPIOCA_PROJECTS_NAME.TapiocaPeriph,
         hre.SDK.eChainId,
-        'PEARLMIT',
+        TAPIOCA_PERIPH_DEPLOY_CONFIG.DEPLOYMENT_NAMES.PEARLMIT,
         tag,
     );
     if (!pearlmit) {

--- a/tasks/deploy/3-deployFinalStack.ts
+++ b/tasks/deploy/3-deployFinalStack.ts
@@ -109,9 +109,10 @@ async function getContracts(
     }
 
     // Get pearlmit
-    const pearlmit = hre.SDK.db.findLocalDeployment(
+    const pearlmit = hre.SDK.db.findGlobalDeployment(
+        TAPIOCA_PROJECTS_NAME.TapiocaPeriph,
         hre.SDK.eChainId,
-        DEPLOYMENT_NAMES.PEARLMIT,
+        'PEARLMIT',
         tag,
     );
     if (!pearlmit) {


### PR DESCRIPTION
- distribution of contributors tokens
- fetch `Pearlmit` from global since this deployment depends on `periph`