### PR TITLE
Absence of restrictions on the sender of the twTAP.claimsReward() function could enable attackers to freeze reward tokens within the Tap token contract #142

### DIFF
--- a/contracts/governance/twTAP.sol
+++ b/contracts/governance/twTAP.sol
@@ -421,15 +421,22 @@ contract TwTAP is
      * @dev Should be safe to claim even after position exit.
      *
      * @param _tokenId tokenId whose rewards to claim
+     * @param _to address to receive the rewards
      *
      * @return amounts_ Claimed amount of each reward token.
      */
-    function claimRewards(uint256 _tokenId) external nonReentrant whenNotPaused returns (uint256[] memory amounts_) {
-        amounts_ = _claimRewards(_tokenId, ownerOf(_tokenId));
+    function claimRewards(uint256 _tokenId, address _to)
+        external
+        nonReentrant
+        whenNotPaused
+        returns (uint256[] memory amounts_)
+    {
+        _requireClaimPermission(_to, _tokenId);
+        amounts_ = _claimRewards(_tokenId, _to);
     }
 
     /**
-     * @notice Exit a twAML participation, delete the voting power if existing and send the TAP to owner.
+     * @notice Exit a twAML participation, delete the voting power if existing and send the TAP to `_to`.
      *
      * @param _tokenId The tokenId of the twTAP position.
      *

--- a/contracts/governance/twTAP.sol
+++ b/contracts/governance/twTAP.sol
@@ -431,6 +431,10 @@ contract TwTAP is
         whenNotPaused
         returns (uint256[] memory amounts_)
     {
+        // Either the owner or a delegate can claim the rewards
+        // In this case it's `TapToken` to claim the rewards on behalf of the user and send them xChain.
+        if (_to != _ownerOf(_tokenId) && _to != msg.sender) revert NotAuthorized();
+
         _requireClaimPermission(_to, _tokenId);
         amounts_ = _claimRewards(_tokenId, _to);
     }

--- a/contracts/governance/twTAP.sol
+++ b/contracts/governance/twTAP.sol
@@ -421,22 +421,15 @@ contract TwTAP is
      * @dev Should be safe to claim even after position exit.
      *
      * @param _tokenId tokenId whose rewards to claim
-     * @param _to address to receive the rewards
      *
      * @return amounts_ Claimed amount of each reward token.
      */
-    function claimRewards(uint256 _tokenId, address _to)
-        external
-        nonReentrant
-        whenNotPaused
-        returns (uint256[] memory amounts_)
-    {
-        _requireClaimPermission(_to, _tokenId);
-        amounts_ = _claimRewards(_tokenId, _to);
+    function claimRewards(uint256 _tokenId) external nonReentrant whenNotPaused returns (uint256[] memory amounts_) {
+        amounts_ = _claimRewards(_tokenId, ownerOf(_tokenId));
     }
 
     /**
-     * @notice Exit a twAML participation, delete the voting power if existing and send the TAP to `_to`.
+     * @notice Exit a twAML participation, delete the voting power if existing and send the TAP to owner.
      *
      * @param _tokenId The tokenId of the twTAP position.
      *


### PR DESCRIPTION
https://github.com/code-423n4/2024-02-tapioca-findings/issues/142