### PR TITLE
carrotsmuggler | [C-01] TOLP token can be burnt while still in TOB CU-86dtgna3t

### DIFF
--- a/tasks/deploy/3-deployFinalStack.ts
+++ b/tasks/deploy/3-deployFinalStack.ts
@@ -113,6 +113,13 @@ async function getTolp(
             DEPLOY_CONFIG.FINAL[hre.SDK.eChainId]!.TOLP.EPOCH_DURATION, // Epoch duration
             pearlmit,
             owner, // Owner
+            '', // TOB
+        ],
+        [
+            {
+                argPosition: 4,
+                deploymentName: DEPLOYMENT_NAMES.TAPIOCA_OPTION_BROKER,
+            },
         ],
     );
 }

--- a/tasks/deployBuilds/finalStack/options/buildTOLP.ts
+++ b/tasks/deployBuilds/finalStack/options/buildTOLP.ts
@@ -1,15 +1,18 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { IDeployerVMAdd } from 'tapioca-sdk/dist/ethers/hardhat/DeployerVM';
 import { TapiocaOptionLiquidityProvision__factory } from '@typechain/index';
+import { IDependentOn } from '@tapioca-sdk/ethers/hardhat/DeployerVM';
 
 export const buildTolp = async (
     hre: HardhatRuntimeEnvironment,
     deploymentName: string,
     args: Parameters<TapiocaOptionLiquidityProvision__factory['deploy']>,
+    dependsOn: IDependentOn[],
 ): Promise<IDeployerVMAdd<TapiocaOptionLiquidityProvision__factory>> => ({
     contract: new TapiocaOptionLiquidityProvision__factory(
         hre.ethers.provider.getSigner(),
     ),
     deploymentName,
     args,
+    dependsOn,
 });


### PR DESCRIPTION
fix(`TOLP`): Prevent `unlock()` if `TOB` is owner [`86dtgna3t`]
- Add new `tapiocaOptionBroker` state var + init in constructor
- Add check in `unlock()`  to revert if owner it `TOB`
- Adapted deployment scripts to changes

https://github.com/carrotsmuggler/taptoken_audit_carrotsmuggler/issues/1