### PR TITLE
Windhustler | Incorrect decoding in decodeLockTwpTapDstMsg 

### DIFF
--- a/contracts/tokens/TapTokenCodec.sol
+++ b/contracts/tokens/TapTokenCodec.sol
@@ -71,10 +71,8 @@ library TapTokenCodec {
 
         // Decoded data
         address user = BytesLib.toAddress(BytesLib.slice(_msg, 0, userOffset_), 0);
-
-        uint96 duration = BytesLib.toUint96(BytesLib.slice(_msg, userOffset_, durationOffset_), 0);
-
-        uint256 amount = BytesLib.toUint256(BytesLib.slice(_msg, durationOffset_, _msg.length - durationOffset_), 0);
+        uint96 duration = BytesLib.toUint96(BytesLib.slice(_msg, userOffset_, 12), 0);
+        uint256 amount = BytesLib.toUint256(BytesLib.slice(_msg, durationOffset_, 32), 0);
 
         // Return structured data
         lockTwTapPositionMsg_ = LockTwTapPositionMsg(user, duration, amount);


### PR DESCRIPTION
fix(`TapTokenCodec`): Correct byte decoding on `decodeLockTwpTapDstMsg()`  [`86dtj5067`]