### PR TITLE
Windhustler | twTap rewards can be stolen in case of pending allowances #9 `86dtj5382`

### DIFF
--- a/contracts/governance/twTAP.sol
+++ b/contracts/governance/twTAP.sol
@@ -595,7 +595,7 @@ contract TwTAP is
      * @dev Use `_isApprovedOrOwner()` internally.
      */
     function _requireClaimPermission(address _to, uint256 _tokenId) internal view {
-        if (!_isApprovedOrOwner(_to, _tokenId) && !isERC721Approved(_ownerOf(_tokenId), _to, address(this), _tokenId)) {
+        if (!isERC721Approved(_ownerOf(_tokenId), _to, address(this), _tokenId)) {
             revert NotApproved(_tokenId, msg.sender);
         }
     }

--- a/contracts/tokens/TapTokenReceiver.sol
+++ b/contracts/tokens/TapTokenReceiver.sol
@@ -159,6 +159,9 @@ contract TapTokenReceiver is BaseTapToken, TapiocaOmnichainReceiver {
 
         // Claim rewards, make sure to have approved this contract on TwTap.
         uint256[] memory claimedAmount_ = twTap.claimRewards(claimTwTapRewardsMsg_.tokenId, address(this));
+        address owner = twTap.ownerOf(claimTwTapRewardsMsg_.tokenId);
+        // Clear the allowance, claimRewards only does an allowance check.
+        pearlmit.clearAllowance(owner, address(twTap), claimTwTapRewardsMsg_.tokenId);
 
         // Check if the claimed amount is equal to the amount of sendParam
         if (


### PR DESCRIPTION
fix(`twTap`): Rem `EIP2612` check on `_requireClaimPermission()` & `Pearlmit` allowance clear [`86dtj5382`]
- Remove `EIP2612` allowance check from `_requireClaimPermission()`
- Checked out `periph` submodule to `GT_CU-86dtj597v_Reset-the-allowance-after-a-transfer-and-add-external-func-to-clear-it-explicitly`
- Using new `Pearlmit::clearAllowance()` to clear allowance after using it

fix(`TapTokenReceiver`): `_claimTwpTapRewardsReceiver()` clears the allowance after `twTap::claimRewards()` [`86dtj5382`]