### PR TITLE
Small twTap claimRewards optimization `CU-86dtjde8p`

### DIFF
--- a/contracts/governance/twTAP.sol
+++ b/contracts/governance/twTAP.sol
@@ -439,22 +439,19 @@ contract TwTAP is
      * @dev Should be safe to claim even after position exit.
      *
      * @param _tokenId tokenId whose rewards to claim
-     * @param _to address to receive the rewards
      *
      * @return amounts_ Claimed amount of each reward token.
      */
-    function claimRewards(uint256 _tokenId, address _to)
-        external
-        nonReentrant
-        whenNotPaused
-        returns (uint256[] memory amounts_)
-    {
+    function claimRewards(uint256 _tokenId) external nonReentrant whenNotPaused returns (uint256[] memory amounts_) {
         // Either the owner or a delegate can claim the rewards
         // In this case it's `TapToken` to claim the rewards on behalf of the user and send them xChain.
-        if (_to != _ownerOf(_tokenId) && _to != msg.sender) revert NotAuthorized();
+        address owner = _ownerOf(_tokenId);
 
-        _requireClaimPermission(_to, _tokenId);
-        amounts_ = _claimRewards(_tokenId, _to);
+        if (owner != msg.sender && !isERC721Approved(owner, msg.sender, address(this), _tokenId)) {
+            revert NotApproved(_tokenId, msg.sender);
+        }
+
+        amounts_ = _claimRewards(_tokenId, msg.sender);
     }
 
     /**
@@ -589,15 +586,6 @@ contract TwTAP is
     /// @notice returns week for timestamp
     function _timestampToWeek(uint256 timestamp) internal view returns (uint256) {
         return ((timestamp - creation) / EPOCH_DURATION);
-    }
-
-    /**
-     * @dev Use `_isApprovedOrOwner()` internally.
-     */
-    function _requireClaimPermission(address _to, uint256 _tokenId) internal view {
-        if (!isERC721Approved(_ownerOf(_tokenId), _to, address(this), _tokenId)) {
-            revert NotApproved(_tokenId, msg.sender);
-        }
     }
 
     /**

--- a/contracts/tokens/TapTokenReceiver.sol
+++ b/contracts/tokens/TapTokenReceiver.sol
@@ -158,7 +158,7 @@ contract TapTokenReceiver is BaseTapToken, TapiocaOmnichainReceiver {
         ClaimTwTapRewardsMsg memory claimTwTapRewardsMsg_ = TapTokenCodec.decodeClaimTwTapRewardsMsg(_data);
 
         // Claim rewards, make sure to have approved this contract on TwTap.
-        uint256[] memory claimedAmount_ = twTap.claimRewards(claimTwTapRewardsMsg_.tokenId, address(this));
+        uint256[] memory claimedAmount_ = twTap.claimRewards(claimTwTapRewardsMsg_.tokenId);
         address owner = twTap.ownerOf(claimTwTapRewardsMsg_.tokenId);
         // Clear the allowance, claimRewards only does an allowance check.
         pearlmit.clearAllowance(owner, address(twTap), claimTwTapRewardsMsg_.tokenId);


### PR DESCRIPTION
patch(`twTap`): Refactored `claimRewards()` to remove `_to` func arg and use `msg.sender`  [`86dthzrv6`]
- Adapted `TapTokenReceiver::_claimTwpTapRewardsReceiver()` to `twTap` changes