### PR TITLE
Remove the Pearlmit code from TOE transferFrom `CU-86dtj04d9`

### DIFF
--- a/contracts/tokens/TapToken.sol
+++ b/contracts/tokens/TapToken.sol
@@ -164,17 +164,6 @@ contract TapToken is BaseTapToken, ModuleManager, ERC20Permit, Pausable {
         _transferOwnership(_data.owner);
     }
 
-    /**
-     * @inheritdoc BaseTapiocaOmnichainEngine
-     */
-    function transferFrom(address from, address to, uint256 value)
-        public
-        override(BaseTapiocaOmnichainEngine, ERC20)
-        returns (bool)
-    {
-        return BaseTapiocaOmnichainEngine.transferFrom(from, to, value);
-    }
-
     /// =====================
     /// Module setup
     /// =====================


### PR DESCRIPTION
fix(`TapToken`): Removed `transferFrom()` `TOE` override [`86dtj04d9`]
- Checked out `periph` submodule to `GT_86dtj04d9_Remove-the-Pearlmit-code-from-TOE-transferFrom`