### PR TITLE
Implement ERC721NftLoader contract to load base URIs + fix aoTAP tokenURI `CU-86dttweeh`

### DIFF
--- a/contracts/erc721NftLoader/ERC721NftLoader.sol
+++ b/contracts/erc721NftLoader/ERC721NftLoader.sol
@@ -24,6 +24,8 @@ import {INFTLoader} from "../interfaces/INFTLoader.sol";
 contract ERC721NftLoader is ERC721, Ownable {
     INFTLoader public nftLoader; // NFT URI loader contract
 
+    string public baseURI;
+
     constructor(string memory _name, string memory _symbol, address _owner) ERC721(_name, _symbol) {
         _transferOwnership(_owner);
     }
@@ -33,10 +35,26 @@ contract ERC721NftLoader is ERC721, Ownable {
      * @inheritdoc ERC721
      */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-        if (address(nftLoader) == address(0)) {
-            return "";
+        // If baseURI is set, use it. Otherwise, use the NFT loader contract.
+        if (bytes(baseURI).length > 0) {
+            return super.tokenURI(tokenId);
+        } else {
+            if (address(nftLoader) == address(0)) {
+                return "";
+            }
+            return INFTLoader(nftLoader).tokenURI(tokenId);
         }
-        return INFTLoader(nftLoader).tokenURI(tokenId);
+    }
+
+    function _baseURI() internal view virtual override returns (string memory) {
+        return baseURI;
+    }
+
+    /**
+     * @notice Set the base URI
+     */
+    function setBaseURI(string memory __baseURI) external onlyOwner {
+        baseURI = __baseURI;
     }
 
     /**

--- a/contracts/governance/twTAP.sol
+++ b/contracts/governance/twTAP.sol
@@ -767,6 +767,10 @@ contract TwTAP is
         return block.chainid;
     }
 
+    function _baseURI() internal view override(ERC721, ERC721NftLoader) returns (string memory) {
+        return baseURI;
+    }
+
     function supportsInterface(bytes4 interfaceId)
         public
         view

--- a/contracts/option-airdrop/aoTAP.sol
+++ b/contracts/option-airdrop/aoTAP.sol
@@ -42,6 +42,8 @@ contract AOTAP is
     uint256 public mintedAOTAP; // total number of AOTAP minted
     address public broker; // address of the onlyBroker
 
+    string public baseURI;
+
     mapping(uint256 => AirdropTapOption) public options; // tokenId => Option
     mapping(uint256 => string) public tokenURIs; // tokenId => tokenURI
 
@@ -67,8 +69,8 @@ contract AOTAP is
     //    READ
     // =========
 
-    function tokenURI(uint256 _tokenId) public view override returns (string memory) {
-        return tokenURIs[_tokenId];
+    function _baseURI() internal view override returns (string memory) {
+        return baseURI;
     }
 
     function isApprovedOrOwner(address _spender, uint256 _tokenId) external view returns (bool) {
@@ -130,6 +132,13 @@ contract AOTAP is
     function brokerClaim() external {
         if (broker != address(0)) revert OnlyOnce();
         broker = msg.sender;
+    }
+
+    /**
+     * @notice Set the base URI for all token IDs.
+     */
+    function setBaseURI(string calldata __baseURI) external onlyOwner {
+        baseURI = __baseURI;
     }
 
     function supportsInterface(bytes4 interfaceId)

--- a/contracts/options/oTAP.sol
+++ b/contracts/options/oTAP.sol
@@ -116,6 +116,10 @@ contract OTAP is ERC721, ERC721Permit, ERC721Enumerable, ERC721NftLoader, Pearlm
         broker = msg.sender;
     }
 
+    function _baseURI() internal view override(ERC721, ERC721NftLoader) returns (string memory) {
+        return baseURI;
+    }
+
     function supportsInterface(bytes4 interfaceId)
         public
         view


### PR DESCRIPTION
feat(`aoTAP`): Updated `tokenURI`  loading [`86dttweeh`]

patch(`oTAP/twTAP`): Using `baseURI` [`86dttweeh`]