### PR TITLE
fix(`tOLP`): Once the tOLP is transferred out, the new owner can never unlock the position

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,4 @@
 [submodule "dep/tapiocaz"]
 	path = dep/tapiocaz
 	url = https://github.com/Tapioca-DAO/tapiocaz
+	branch = master

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,7 @@ remappings = [
 	"permitc/=dep/tap-utils/lib/permitc/src/", # Needs to be init in the periph repo
 	"tapioca-mocks/=dep/tapioca-mocks/contracts/",
 	"tapioca-bar/=dep/tapioca-bar/contracts/",
+	"tapiocaz/=dep/tapiocaz/contracts/",
 ]
 
 [profile.default.fuzz]

--- a/test/unit/options/TapiocaOptionBroker/TOB_exitPosition.t.sol
+++ b/test/unit/options/TapiocaOptionBroker/TOB_exitPosition.t.sol
@@ -10,6 +10,13 @@ contract TOB_exitPosition is TobBaseTest, TWAML {
     uint256 public constant TOLP_TOKEN_ID = 1;
     uint256 public constant VIRTUAL_TOTAL_AMOUNT = 50_000 ether; // See @TapiocaOptionBroker
 
+    uint256 public SGL_ASSET_ID;
+
+    function setUp() public virtual override {
+        super.setUp();
+        SGL_ASSET_ID = ybAssetIdToftSglEthMarket;
+    }
+
     function test_RevertWhen_PositionDoesntExist() external {
         // it should revert
         vm.expectRevert(TapiocaOptionBroker.PositionNotValid.selector);
@@ -27,7 +34,7 @@ contract TOB_exitPosition is TobBaseTest, TWAML {
     function test_WhenSglIsInRescueMode(uint128 __tOLPLockAmount) external whenPositionExists whenLockIsNotExpired {
         (__tOLPLockAmount,) = _boundValues(__tOLPLockAmount, 0);
         _setupAndParticipate(aliceAddr, __tOLPLockAmount, TOLP_LOCK_DURATION);
-        _setSglInRescue(IERC20(address(singularityEthMarket)), singularityEthMarketAssetId);
+        _setSglInRescue(IERC20(address(toftSglEthMarket)), SGL_ASSET_ID);
 
         (,,, uint256 cumulativeBefore) = tob.twAML(1);
         // it should continue
@@ -61,13 +68,13 @@ contract TOB_exitPosition is TobBaseTest, TWAML {
 
         uint256 epoch = 1;
         address paymentToken = address(daiMock);
-        (,,, uint256 cumulativeBefore) = tob.twAML(1);
+        (,,, uint256 cumulativeBefore) = tob.twAML(SGL_ASSET_ID);
 
         // it should emit ExitPosition
         vm.expectEmit(true, true, true, false);
         emit TapiocaOptionBroker.ExitPosition(epoch, OTAP_TOKEN_ID, OTAP_TOKEN_ID);
         tob.exitPosition(OTAP_TOKEN_ID);
-        (uint256 totalParticipants,, uint256 totalDeposited, uint256 cumulativeAfter) = tob.twAML(1);
+        (uint256 totalParticipants,, uint256 totalDeposited, uint256 cumulativeAfter) = tob.twAML(SGL_ASSET_ID);
 
         // it should update twAML cumulative
         assertLt(cumulativeAfter, cumulativeBefore, "TOB_exitPosition::test_WhenLockIsExpired: Invalid cumulative");

--- a/test/unit/options/TapiocaOptionBroker/TOB_getOTCDealDetails.t.sol
+++ b/test/unit/options/TapiocaOptionBroker/TOB_getOTCDealDetails.t.sol
@@ -28,7 +28,7 @@ contract TOB_getOTCDealDetails is TobBaseTest, TWAML {
     {
         // it should revert
         vm.expectRevert(TapiocaOptionBroker.PaymentTokenNotSupported.selector);
-        tob.getOTCDealDetails(1, ERC20(address(singularityEthMarket)), 0);
+        tob.getOTCDealDetails(1, ERC20(address(toftSglEthMarket)), 0);
     }
 
     function test_RevertWhen_InEpochCooldown(uint128 _lockAmount, uint128 _lockDuration)

--- a/test/unit/options/TapiocaOptionBroker/TOB_getOptionPosition.t.sol
+++ b/test/unit/options/TapiocaOptionBroker/TOB_getOptionPosition.t.sol
@@ -15,7 +15,7 @@ contract TOB_getOptionPosition is TobBaseTest {
         _tobParticipate(aliceAddr, _amount, _lockDuration);
         // it should return the right option position
         (LockPosition memory tOLPLockPosition, TapOption memory oTAPPosition,) = tob.getOptionPosition(1, 0);
-        assertEq(tOLPLockPosition.sglAssetID, 1, "TOB_getOptionPosition: Invalid sglAssetID");
+        assertEq(tOLPLockPosition.sglAssetID, 102, "TOB_getOptionPosition: Invalid sglAssetID");
         assertEq(oTAPPosition.tOLP, 1, "TOB_getOptionPosition: Invalid tOLP");
     }
 }

--- a/test/unit/options/TapiocaOptionBroker/TOB_getSingularityPoolInfo.t.sol
+++ b/test/unit/options/TapiocaOptionBroker/TOB_getSingularityPoolInfo.t.sol
@@ -10,8 +10,8 @@ contract getSingularityPoolInfo is TobBaseTest {
 
         // it should return the right values
         (uint256 assetId, uint256 totalDeposited, uint256 weight, bool isInRescue,,,,) =
-            tob.getSingularityPoolInfo(IERC20(address(singularityEthMarket)), 1);
-        assertEq(assetId, 1, "TOB_getSingularityPoolInfo: Invalid assetId");
+            tob.getSingularityPoolInfo(IERC20(address(toftSglEthMarket)), 1);
+        assertEq(assetId, ybAssetIdToftSglEthMarket, "TOB_getSingularityPoolInfo: Invalid assetId");
         assertEq(totalDeposited, _lockAmount, "TOB_getSingularityPoolInfo: Invalid totalDeposited");
         assertEq(weight, 1, "TOB_getSingularityPoolInfo: Invalid weight");
         assertEq(isInRescue, false, "TOB_getSingularityPoolInfo: Invalid isInRescue");

--- a/test/unit/options/TapiocaOptionBroker/TOB_participate.t.sol
+++ b/test/unit/options/TapiocaOptionBroker/TOB_participate.t.sol
@@ -14,7 +14,7 @@ contract TOB_participate is TobBaseTest, TWAML {
 
     function setUp() public virtual override {
         super.setUp();
-        SGL_ASSET_ID = singularityEthMarketAssetId;
+        SGL_ASSET_ID = ybAssetIdToftSglEthMarket;
     }
 
     /**
@@ -296,7 +296,8 @@ contract TOB_participate is TobBaseTest, TWAML {
         whenItShouldParticipate(_lockAmount, _lockDuration, ENDING_EPOCH, true, true);
 
         // it should update cumulative
-        (uint256 totalParticipants, uint256 averageMagnitude, uint256 totalDeposited, uint256 cumulative) = tob.twAML(1);
+        (uint256 totalParticipants, uint256 averageMagnitude, uint256 totalDeposited, uint256 cumulative) =
+            tob.twAML(SGL_ASSET_ID);
         assertEq(
             totalParticipants, 1, "TOB_participate::test_WhenLockerDoesNotHaveVotingPower: Invalid totalParticipants"
         );
@@ -331,7 +332,7 @@ contract TOB_participate is TobBaseTest, TWAML {
     ) internal {
         // it should emit Participate
         vm.expectEmit(true, true, false, false);
-        emit TapiocaOptionBroker.Participate(tob.epoch(), TOLP_TOKEN_ID, _lockAmount, 1, 0, 0);
+        emit TapiocaOptionBroker.Participate(tob.epoch(), SGL_ASSET_ID, _lockAmount, 1, 0, 0);
         tob.participate(TOLP_TOKEN_ID, 0);
         // it should save the twAML participation
         (bool hasVotingPower, bool divergenceForce, uint256 averageMagnitude) = tob.participants(1);

--- a/test/unit/options/TapiocaOptionBroker/TOB_refreshTotalDeposited.t.sol
+++ b/test/unit/options/TapiocaOptionBroker/TOB_refreshTotalDeposited.t.sol
@@ -14,12 +14,12 @@ contract TOB_refreshTotalDeposited is TobBaseTest {
             returnArray.length, 0, "TOB_refreshTotalDeposited::test_WhenParamArrayIsEmpty: Invalid returnArray length"
         );
         assertEq(
-            tob.lastTotalDepositedForSgl(1),
+            tob.lastTotalDepositedForSgl(ybAssetIdToftSglEthMarket),
             0,
             "TOB_refreshTotalDeposited::test_WhenParamArrayIsEmpty: Invalid lastTotalDepositedForSgl"
         );
         assertEq(
-            tob.lastTotalDepositRefreshSgl(1),
+            tob.lastTotalDepositRefreshSgl(ybAssetIdToftSglEthMarket),
             0,
             "TOB_refreshTotalDeposited::test_WhenParamArrayIsEmpty: Invalid lastTotalDepositRefreshSgl"
         );
@@ -33,7 +33,7 @@ contract TOB_refreshTotalDeposited is TobBaseTest {
     function test_WhenRefreshCooldownIsNotMet() external whenParamArrayIsSet {
         // it should return the previously set value
         uint256[] memory sglArray = new uint256[](1);
-        sglArray[0] = 1;
+        sglArray[0] = ybAssetIdToftSglEthMarket;
         uint256[] memory returnArray = tob.refreshTotalDeposited(sglArray);
         assertEq(
             returnArray.length,
@@ -41,12 +41,12 @@ contract TOB_refreshTotalDeposited is TobBaseTest {
             "TOB_refreshTotalDeposited::test_WhenRefreshCooldownIsNotMet: Invalid returnArray length"
         );
         assertEq(
-            tob.lastTotalDepositedForSgl(1),
+            tob.lastTotalDepositedForSgl(ybAssetIdToftSglEthMarket),
             PARTICIPATE_AMOUNT,
             "TOB_refreshTotalDeposited::test_WhenRefreshCooldownIsNotMet: Invalid lastTotalDepositedForSgl"
         );
         assertEq(
-            tob.lastTotalDepositRefreshSgl(1),
+            tob.lastTotalDepositRefreshSgl(ybAssetIdToftSglEthMarket),
             block.timestamp,
             "TOB_refreshTotalDeposited::test_WhenRefreshCooldownIsNotMet: Invalid lastTotalDepositRefreshSgl"
         );
@@ -55,15 +55,15 @@ contract TOB_refreshTotalDeposited is TobBaseTest {
     function test_WhenRefreshCooldownIsMet() external whenParamArrayIsSet {
         // Setup previous value
         uint256[] memory sglArray = new uint256[](1);
-        sglArray[0] = 1;
+        sglArray[0] = ybAssetIdToftSglEthMarket;
         uint256[] memory returnArray = tob.refreshTotalDeposited(sglArray);
         assertEq(
-            tob.lastTotalDepositedForSgl(1),
+            tob.lastTotalDepositedForSgl(ybAssetIdToftSglEthMarket),
             PARTICIPATE_AMOUNT,
             "TOB_refreshTotalDeposited::test_WhenRefreshCooldownIsMet: Invalid lastTotalDepositedForSgl"
         );
         assertEq(
-            tob.lastTotalDepositRefreshSgl(1),
+            tob.lastTotalDepositRefreshSgl(ybAssetIdToftSglEthMarket),
             block.timestamp,
             "TOB_refreshTotalDeposited::test_WhenRefreshCooldownIsMet: Invalid lastTotalDepositRefreshSgl"
         );
@@ -71,19 +71,19 @@ contract TOB_refreshTotalDeposited is TobBaseTest {
         // Update values to new value
         skip(tob.EPOCH_DURATION() / 2); // Arbitrary value to simulate time passing
         _tobParticipate(bobAddr, uint200(PARTICIPATE_AMOUNT), uint128(tob.EPOCH_DURATION()), 2);
-        sglArray[0] = 1;
+        sglArray[0] = ybAssetIdToftSglEthMarket;
         returnArray = tob.refreshTotalDeposited(sglArray);
 
         // it should update lastTotalDepositedForSgl with the newly fetch value
         assertEq(
-            tob.lastTotalDepositedForSgl(1),
+            tob.lastTotalDepositedForSgl(ybAssetIdToftSglEthMarket),
             PARTICIPATE_AMOUNT * 2,
             "TOB_refreshTotalDeposited::test_WhenRefreshCooldownIsMet: Invalid lastTotalDepositedForSgl"
         );
 
         // it should update lastTotalDepositRefreshSgl to block.timestamp
         assertEq(
-            tob.lastTotalDepositRefreshSgl(1),
+            tob.lastTotalDepositRefreshSgl(ybAssetIdToftSglEthMarket),
             block.timestamp,
             "TOB_refreshTotalDeposited::test_WhenRefreshCooldownIsMet: Invalid lastTotalDepositRefreshSgl"
         );

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_activateSGLPoolRescue.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_activateSGLPoolRescue.t.sol
@@ -8,10 +8,10 @@ contract TOLP_activateSGLPoolRescue is TolpBaseTest {
         // it should set rescue to true
         vm.startPrank(adminAddr);
 
-        tolp.requestSglPoolRescue(1);
+        tolp.requestSglPoolRescue(ybAssetIdToftSglEthMarket);
         vm.warp(block.timestamp + tolp.rescueCooldown());
-        tolp.activateSGLPoolRescue(IERC20(address(singularityEthMarket)));
-        (,,, bool rescue) = tolp.activeSingularities(IERC20(address(singularityEthMarket)));
+        tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
+        (,,, bool rescue) = tolp.activeSingularities(IERC20(address(toftSglEthMarket)));
         assertEq(rescue, true, "TOLP_activateSGLPoolRescue: Invalid rescue");
     }
 
@@ -20,18 +20,18 @@ contract TOLP_activateSGLPoolRescue is TolpBaseTest {
         vm.startPrank(adminAddr);
 
         vm.expectRevert(NotRegistered.selector);
-        tolp.activateSGLPoolRescue(IERC20(address(singularityEthMarket)));
+        tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
     }
 
     function test_RevertWhen_SglRescueIsTrue() external registerSingularityPool {
         // it should revert
         vm.startPrank(adminAddr);
 
-        tolp.requestSglPoolRescue(1);
+        tolp.requestSglPoolRescue(ybAssetIdToftSglEthMarket);
         vm.warp(block.timestamp + tolp.rescueCooldown());
-        tolp.activateSGLPoolRescue(IERC20(address(singularityEthMarket)));
+        tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
         vm.expectRevert(AlreadyActive.selector);
-        tolp.activateSGLPoolRescue(IERC20(address(singularityEthMarket)));
+        tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
     }
 
     function test_RevertWhen_SglRescueRequestIs0() external registerSingularityPool {
@@ -39,15 +39,15 @@ contract TOLP_activateSGLPoolRescue is TolpBaseTest {
         vm.startPrank(adminAddr);
 
         vm.expectRevert(NotActive.selector);
-        tolp.activateSGLPoolRescue(IERC20(address(singularityEthMarket)));
+        tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
     }
 
     function test_RevertWhen_RescueCooldownNotMet() external registerSingularityPool {
         // it should revert
         vm.startPrank(adminAddr);
 
-        tolp.requestSglPoolRescue(1);
+        tolp.requestSglPoolRescue(ybAssetIdToftSglEthMarket);
         vm.expectRevert(RescueCooldownNotReached.selector);
-        tolp.activateSGLPoolRescue(IERC20(address(singularityEthMarket)));
+        tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
     }
 }

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_lock.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_lock.t.sol
@@ -12,8 +12,8 @@ contract TOLP_lock is TolpBaseTest {
 
     function setUp() public virtual override {
         super.setUp();
-        SGL_TO_LOCK = IERC20(address(singularityEthMarket));
-        SGL_ASSET_ID = singularityEthMarketAssetId;
+        SGL_TO_LOCK = IERC20(address(toftSglEthMarket));
+        SGL_ASSET_ID = ybAssetIdToftSglEthMarket;
     }
 
     function test_RevertWhen_PausedPaused(uint128 _lockDuration, uint128 _ybShares) external {

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_registerSingularity.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_registerSingularity.t.sol
@@ -7,7 +7,7 @@ contract TOLP_registerSingularity is TolpBaseTest {
     function test_RevertWhen_NotOwner() external {
         // it should revert
         vm.expectRevert("Ownable: caller is not the owner");
-        tolp.registerSingularity(IERC20(address(singularityEthMarket)), singularityEthMarketAssetId, 0);
+        tolp.registerSingularity(IERC20(address(toftSglEthMarket)), ybAssetIdToftSglEthMarket, 0);
     }
 
     function test_RevertWhen_AssetIdNotValid() external {
@@ -15,7 +15,7 @@ contract TOLP_registerSingularity is TolpBaseTest {
         vm.startPrank(adminAddr);
 
         vm.expectRevert(AssetIdNotValid.selector);
-        tolp.registerSingularity(IERC20(address(singularityEthMarket)), 0, 0);
+        tolp.registerSingularity(IERC20(address(toftSglEthMarket)), 0, 0);
     }
 
     function test_RevertWhen_AssetIdAlreadyRegistered() external registerSingularityPool {
@@ -23,7 +23,7 @@ contract TOLP_registerSingularity is TolpBaseTest {
         vm.startPrank(adminAddr);
 
         vm.expectRevert(DuplicateAssetId.selector);
-        tolp.registerSingularity(IERC20(address(singularityEthMarket)), singularityEthMarketAssetId, 0);
+        tolp.registerSingularity(IERC20(address(toftSglEthMarket)), ybAssetIdToftSglEthMarket, 0);
     }
 
     function test_RevertWhen_SglIsAlreadyRegistered() external registerSingularityPool {
@@ -31,7 +31,7 @@ contract TOLP_registerSingularity is TolpBaseTest {
         vm.startPrank(adminAddr);
 
         vm.expectRevert(AlreadyRegistered.selector);
-        tolp.registerSingularity(IERC20(address(singularityEthMarket)), 10, 0);
+        tolp.registerSingularity(IERC20(address(toftSglEthMarket)), 10, 0);
     }
 
     function test_ShouldRegisterTheSingularity() external registerSingularityPool {

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_setSGLPoolWeight.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_setSGLPoolWeight.t.sol
@@ -8,15 +8,15 @@ contract TOLP_setSGLPoolWeight is TolpBaseTest {
         // it should revert
         vm.startPrank(adminAddr);
         vm.expectRevert(NotRegistered.selector);
-        tolp.setSGLPoolWeight(IERC20(address(singularityEthMarket)), singularityEthMarketAssetId);
+        tolp.setSGLPoolWeight(IERC20(address(toftSglEthMarket)), ybAssetIdToftSglEthMarket);
     }
 
     function test_ShouldSetTheWeightOfThePool() external registerSingularityPool {
         // it should set the weight of the pool
         vm.startPrank(adminAddr);
-        tolp.setSGLPoolWeight(IERC20(address(singularityEthMarket)), 3);
+        tolp.setSGLPoolWeight(IERC20(address(toftSglEthMarket)), 3);
 
-        (,, uint256 poolWeight,) = tolp.activeSingularities(IERC20(address(singularityEthMarket)));
+        (,, uint256 poolWeight,) = tolp.activeSingularities(IERC20(address(toftSglEthMarket)));
         assertEq(poolWeight, 3, "TOLP_setSGLPoolWeight: Invalid weight");
         //     and also update the total weights
         assertEq(tolp.totalSingularityPoolWeights(), 7, "TOLP_setSGLPoolWeight: Invalid total weight");

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_unlock.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_unlock.t.sol
@@ -11,8 +11,8 @@ contract TOLP_unlock is TolpBaseTest {
 
     function setUp() public virtual override {
         super.setUp();
-        SGL_ADDRESS = IERC20(address(singularityEthMarket));
-        SGL_ASSET_ID = singularityEthMarketAssetId;
+        SGL_ADDRESS = IERC20(address(toftSglEthMarket));
+        SGL_ASSET_ID = ybAssetIdToftSglEthMarket;
     }
 
     function test_RevertWhen_Paused(uint128 _weight, uint128 _lockDuration)

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_unregisterSingularity.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_unregisterSingularity.t.sol
@@ -7,7 +7,7 @@ contract TOLP_unregisterSingularity is TolpBaseTest {
     function test_RevertWhen_NotOwner() external {
         // it should revert
         vm.expectRevert("Ownable: caller is not the owner");
-        tolp.unregisterSingularity(IERC20(address(singularityEthMarket)));
+        tolp.unregisterSingularity(IERC20(address(toftSglEthMarket)));
     }
 
     function test_RevertWhen_AssetId0() external {
@@ -15,7 +15,7 @@ contract TOLP_unregisterSingularity is TolpBaseTest {
         vm.startPrank(adminAddr);
 
         vm.expectRevert(NotRegistered.selector);
-        tolp.unregisterSingularity(IERC20(address(singularityEthMarket)));
+        tolp.unregisterSingularity(IERC20(address(toftSglEthMarket)));
     }
 
     function test_RevertWhen_NotInRescue() external registerSingularityPool {
@@ -23,27 +23,31 @@ contract TOLP_unregisterSingularity is TolpBaseTest {
         vm.startPrank(adminAddr);
 
         vm.expectRevert(NotInRescueMode.selector);
-        tolp.unregisterSingularity(IERC20(address(singularityEthMarket)));
+        tolp.unregisterSingularity(IERC20(address(toftSglEthMarket)));
     }
 
     function test_ShouldUnregisterTheSingularity()
         external
         registerSingularityPool
-        setSglInRescue(IERC20(address(singularityEthMarket)), singularityEthMarketAssetId)
+        setSglInRescue(IERC20(address(toftSglEthMarket)), ybAssetIdToftSglEthMarket)
     {
         // it should unregister the singularity
         vm.startPrank(adminAddr);
 
-        tolp.unregisterSingularity(IERC20(address(singularityEthMarket)));
+        tolp.unregisterSingularity(IERC20(address(toftSglEthMarket)));
         //     delete the activeSingularities
-        (uint256 assetId,,,) = tolp.activeSingularities(IERC20(address(singularityEthMarket)));
+        (uint256 assetId,,,) = tolp.activeSingularities(IERC20(address(toftSglEthMarket)));
         assertEq(assetId, 0, "TOLP_unregisterSingularity: Invalid assetId");
         //     delete sglAssetIDToAddress
         assertEq(
-            address(tolp.sglAssetIDToAddress(singularityEthMarketAssetId)), address(0), "TOLP_unregisterSingularity: Invalid sglAssetToAddress"
+            address(tolp.sglAssetIDToAddress(ybAssetIdToftSglEthMarket)),
+            address(0),
+            "TOLP_unregisterSingularity: Invalid sglAssetToAddress"
         );
         //     delete sglRescueRequest
-        assertEq(tolp.sglRescueRequest(singularityEthMarketAssetId), 0, "TOLP_unregisterSingularity: Invalid sglRescueRequest");
+        assertEq(
+            tolp.sglRescueRequest(ybAssetIdToftSglEthMarket), 0, "TOLP_unregisterSingularity: Invalid sglRescueRequest"
+        );
         //     delete singularities array
         assertEq(tolp.getSingularities().length, 4, "TOLP_unregisterSingularity: Invalid singularities array");
     }

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TolpBaseTest.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TolpBaseTest.sol
@@ -113,7 +113,7 @@ contract TolpBaseTest is UnitBaseTest {
     modifier setPoolRescue() {
         vm.startPrank(adminAddr);
         tolp.setRescueCooldown(0);
-        tolp.requestSglPoolRescue(1);
+        tolp.requestSglPoolRescue(ybAssetIdToftSglEthMarket);
         tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
         vm.stopPrank();
         _;

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TolpBaseTest.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TolpBaseTest.sol
@@ -15,10 +15,25 @@ import {
 } from "../../UnitBaseTest.sol";
 import {SingularityPool} from "contracts/options/TapiocaOptionLiquidityProvision.sol";
 
+import {TapiocaOmnichainExtExec} from "tap-utils/tapiocaOmnichainEngine/extension/TapiocaOmnichainExtExec.sol";
+import {TOFTOptionsReceiverModule} from "tapiocaz/tOFT/modules/TOFTOptionsReceiverModule.sol";
+import {TOFTGenericReceiverModule} from "tapiocaz/tOFT/modules/TOFTGenericReceiverModule.sol";
+import {TOFTMarketReceiverModule} from "tapiocaz/tOFT/modules/TOFTMarketReceiverModule.sol";
+import {TOFTInitStruct, TOFTModulesInitStruct} from "tap-utils/interfaces/oft/ITOFT.sol";
+import {mTOFTReceiver} from "tapiocaz/tOFT/modules/mTOFTReceiver.sol";
+import {IYieldBox, TokenType} from "yieldbox/YieldBox.sol";
+import {TOFTReceiver} from "tapiocaz/tOFT/modules/TOFTReceiver.sol";
+import {TOFTSender} from "tapiocaz/tOFT/modules/TOFTSender.sol";
+import {TOFTVault} from "tapiocaz/tOFT/TOFTVault.sol";
+import {TOFT} from "tapiocaz/tOFT/TOFT.sol";
+
 import "forge-std/console.sol";
 
 contract TolpBaseTest is UnitBaseTest {
     TapiocaOptionLiquidityProvision public tolp;
+    TOFT public toftSglEthMarket;
+    address public ybStratToftSglEthMarket;
+    uint256 public ybAssetIdToftSglEthMarket;
 
     uint256 public MIN_USDO_PARTICIPATION_BOUNDARY = 1e18;
     uint256 public MAX_USDO_PARTICIPATION_BOUNDARY = 1e27;
@@ -59,6 +74,19 @@ contract TolpBaseTest is UnitBaseTest {
         super.setUp();
 
         tolp = createTolpInstance(address(yieldBox), 7 days, IPearlmit(address(pearlmit)), address(penrose), adminAddr);
+        toftSglEthMarket = createTOFT(
+            "TOFT SGL ETH Market",
+            address(yieldBox),
+            address(cluster),
+            address(singularityEthMarket),
+            address(pearlmit),
+            EID_A,
+            EID_A
+        );
+        ybStratToftSglEthMarket = address(createYieldBoxEmptyStrategy(address(yieldBox), address(toftSglEthMarket)));
+        ybAssetIdToftSglEthMarket = IYieldBox(address(yieldBox)).registerAsset(
+            TokenType.ERC20, address(toftSglEthMarket), ybStratToftSglEthMarket, 0
+        );
     }
 
     /**
@@ -71,7 +99,7 @@ contract TolpBaseTest is UnitBaseTest {
 
     function _registerSingularityPool() internal {
         vm.startPrank(adminAddr);
-        tolp.registerSingularity(IERC20(address(singularityEthMarket)), singularityEthMarketAssetId, 0); // sglAddr, yb assetId, weight
+        tolp.registerSingularity(IERC20(address(toftSglEthMarket)), ybAssetIdToftSglEthMarket, 0); // sglAddr, yb assetId, weight
         tolp.registerSingularity(IERC20(address(0x2)), 2, 0);
         tolp.registerSingularity(IERC20(address(0x3)), 3, 0);
         tolp.registerSingularity(IERC20(address(0x4)), 4, 0);
@@ -86,7 +114,7 @@ contract TolpBaseTest is UnitBaseTest {
         vm.startPrank(adminAddr);
         tolp.setRescueCooldown(0);
         tolp.requestSglPoolRescue(1);
-        tolp.activateSGLPoolRescue(IERC20(address(singularityEthMarket)));
+        tolp.activateSGLPoolRescue(IERC20(address(toftSglEthMarket)));
         vm.stopPrank();
         _;
     }
@@ -114,18 +142,18 @@ contract TolpBaseTest is UnitBaseTest {
     function _createLock(address _user, uint256 _weight, uint128 _lockDuration) internal {
         depositCollateral(_user, _weight);
 
-        (, uint256 shares) = yieldBox.depositAsset(singularityEthMarketAssetId, _user, _weight);
+        (, uint256 shares) = yieldBox.depositAsset(ybAssetIdToftSglEthMarket, _user, _weight);
         vm.startPrank(_user);
         yieldBox.setApprovalForAll(address(pearlmit), true);
         pearlmit.approve(
             1155,
             address(yieldBox),
-            singularityEthMarketAssetId,
+            ybAssetIdToftSglEthMarket,
             address(tolp),
             type(uint200).max,
             uint48(block.timestamp + 1)
         );
-        tolp.lock(_user, IERC20(address(singularityEthMarket)), _lockDuration, uint128(shares));
+        tolp.lock(_user, IERC20(address(toftSglEthMarket)), _lockDuration, uint128(shares));
         vm.stopPrank();
     }
 
@@ -146,5 +174,52 @@ contract TolpBaseTest is UnitBaseTest {
         _lockAmount = uint128(bound(_lockAmount, MIN_USDO_PARTICIPATION_BOUNDARY, MAX_USDO_PARTICIPATION_BOUNDARY));
         _lockDuration = uint128(tolp.EPOCH_DURATION() * bound(_lockDuration, 1, 2));
         return (_lockAmount, _lockDuration);
+    }
+
+    // =========
+    //  TapiocaZ
+    // =========
+
+    function createTOFT(
+        string memory name,
+        address yieldBox,
+        address cluster,
+        address erc20,
+        address pearlmit,
+        uint32 endointId,
+        uint32 hostEid
+    ) public returns (TOFT toft) {
+        TOFTVault toftVault = new TOFTVault(address(erc20));
+        TapiocaOmnichainExtExec extExec = new TapiocaOmnichainExtExec();
+
+        TOFTInitStruct memory toftInitStruct = TOFTInitStruct({
+            name: name,
+            symbol: name,
+            endpoint: address(endpoints[endointId]),
+            delegate: address(this), // owner
+            yieldBox: yieldBox,
+            cluster: cluster,
+            erc20: erc20,
+            vault: address(toftVault),
+            hostEid: hostEid,
+            extExec: address(extExec),
+            pearlmit: IPearlmit(pearlmit)
+        });
+
+        {
+            TOFTSender toftSender = new TOFTSender(toftInitStruct);
+            mTOFTReceiver toftReceiver = new mTOFTReceiver(toftInitStruct);
+            TOFTMarketReceiverModule toftMarketReceiverModule = new TOFTMarketReceiverModule(toftInitStruct);
+            TOFTOptionsReceiverModule toftOptionsReceiverModule = new TOFTOptionsReceiverModule(toftInitStruct);
+            TOFTGenericReceiverModule toftGenericReceiverModule = new TOFTGenericReceiverModule(toftInitStruct);
+            TOFTModulesInitStruct memory toftModulesInitStruct = TOFTModulesInitStruct({
+                tOFTSenderModule: address(toftSender),
+                tOFTReceiverModule: address(toftReceiver),
+                marketReceiverModule: address(toftMarketReceiverModule),
+                optionsReceiverModule: address(toftOptionsReceiverModule),
+                genericReceiverModule: address(toftGenericReceiverModule)
+            });
+            toft = new TOFT(toftInitStruct, toftModulesInitStruct);
+        }
     }
 }


### PR DESCRIPTION
fix(`tOLP`): Once the tOLP is transferred out, the new owner can never unlock the position

https://github.com/Enigma-Dark/Tapioca-Engagement-June/issues/47

chore: Add `tapiocaz` remapping + submodule branch checkout

chore(`test`): Bugfix, using tOFT wrapped SGL instead of SGL only

patch(`test`): Adapted tests for latest changes