### PR TITLE
fix(`tOLP`):Admin cannot collect totalPenalties because totalPenalties state is not updated properly

### DIFF
--- a/contracts/options/TapiocaOptionLiquidityProvision.sol
+++ b/contracts/options/TapiocaOptionLiquidityProvision.sol
@@ -88,7 +88,7 @@ contract TapiocaOptionLiquidityProvision is
     // Debt penalty starts from 10% and goes down to 0.5% linearly
     uint256 public maxDebtPenalty = 1000;
     uint256 public minDebtPenalty = 500;
-    uint256 public totalPenalties; // Total amount of penalties paid
+    mapping(uint256 sglId => uint256 penalty) public totalPenalties; // Total amount of penalties paid
 
     error NotRegistered();
     error InvalidSingularity();
@@ -345,6 +345,7 @@ contract TapiocaOptionLiquidityProvision is
                 yieldBox.transfer(address(this), tokenOwner, lockPosition.sglAssetID, lockPosition.ybShares);
             } else {
                 uint256 penalty = _getDebtPenaltyAmount(lockPosition);
+                totalPenalties[sgl.sglAssetID] += penalty;
                 yieldBox.transfer(address(this), tokenOwner, lockPosition.sglAssetID, lockPosition.ybShares - penalty);
             }
         }
@@ -526,7 +527,7 @@ contract TapiocaOptionLiquidityProvision is
      */
     function harvestPenalties(address _to, uint256 _amount, uint256 _sglAssetId) external {
         if (!cluster.hasRole(msg.sender, keccak256("HARVEST_TOLP")) && msg.sender != owner()) revert NotAuthorized();
-        totalPenalties -= _amount;
+        totalPenalties[_sglAssetId] -= _amount;
         yieldBox.transfer(address(this), _to, _sglAssetId, _amount);
 
         emit HarvestPenalties(_to, _amount);

--- a/test/unit/UnitBaseTest.sol
+++ b/test/unit/UnitBaseTest.sol
@@ -496,7 +496,7 @@ contract UnitBaseTest is TestHelper {
         vm.stopPrank();
     }
 
-    function depositCollateral(address to, uint256 amount) public {
+    function depositBBCollateral(address to, uint256 amount) public {
         vm.startPrank(to);
 
         // approvals
@@ -529,6 +529,30 @@ contract UnitBaseTest is TestHelper {
         uint256 amountUsd = (amount * rate * 50) / 1e21;
         (modules, calls) = marketHelper.borrow(to, to, amountUsd);
         bigBangEthMarket.execute(modules, calls, true);
+        vm.stopPrank();
+    }
+
+    function depositSGLCollateral(address to, uint256 amount) public {
+        vm.startPrank(to);
+        deal(address(ethTokenPenrose), to, amount);
+        BoringIERC20(ethTokenPenrose).approve(address(yieldBox), type(uint256).max);
+        BoringIERC20(ethTokenPenrose).approve(address(pearlmit), type(uint256).max);
+        yieldBox.setApprovalForAll(address(singularityEthMarket), true);
+        yieldBox.setApprovalForAll(address(pearlmit), true);
+        pearlmit.approve(
+            1155,
+            address(yieldBox),
+            ethTokenPenroseId,
+            address(singularityEthMarket),
+            type(uint200).max,
+            uint48(block.timestamp)
+        );
+
+        uint256 share = yieldBox.toShare(ethTokenPenroseId, amount, false);
+        yieldBox.depositAsset(ethTokenPenroseId, to, to, 0, share);
+
+        (BBModule[] memory modules, bytes[] memory calls) = marketHelper.addCollateral(to, to, false, 0, share);
+        singularityEthMarket.execute(modules, calls, true);
         vm.stopPrank();
     }
 

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_getDebtPenaltyAmount.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_getDebtPenaltyAmount.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.22;
+
+import {TolpBaseTest, IERC20, TapiocaOptionLiquidityProvision} from "./TolpBaseTest.sol";
+import {LockPosition} from "contracts/options/TapiocaOptionLiquidityProvision.sol";
+import {Module as BBModule} from "tap-utils/interfaces/bar/IMarket.sol";
+
+contract TOLP_getDebtPenaltyAmount is TolpBaseTest {
+    uint256 constant TOLP_TOKEN_ID = 1;
+    IERC20 SGL_ADDRESS;
+    uint256 SGL_ASSET_ID;
+
+    function setUp() public virtual override {
+        super.setUp();
+        SGL_ADDRESS = IERC20(address(toftSglEthMarket));
+        SGL_ASSET_ID = ybAssetIdToftSglEthMarket;
+    }
+
+    function test_WhenUserIsLockedAndDoesNotHaveEnoughBBDebt(uint128 _weight, uint128 _lockDuration)
+        external
+        initAndCreateLock(aliceAddr, _weight, _lockDuration)
+    {
+        (_weight,) = _boundValues(_weight, _lockDuration);
+        _repayDebt(aliceAddr, bigBangEthMarket._userBorrowPart(aliceAddr) / 2);
+        vm.prank(adminAddr);
+        tolp.setMaxDebtBuffer(100000);
+        (bool canLock,,) = tolp.canLockWithDebt(aliceAddr, SGL_ASSET_ID, tolp.userLockedUsdo(aliceAddr));
+        assertEq(canLock, false, "TOLP_getDebtPenaltyAmount::test_WhenUserIsLockedAndDoesNotHaveEnoughBBDebt canLock");
+        // it should unlock earlier
+        tolp.unlock(TOLP_TOKEN_ID, SGL_ADDRESS);
+        // it should apply the penalty
+        uint256 penalty = tolp.totalPenalties(SGL_ASSET_ID);
+        assertGt(penalty, 0, "TOLP_getDebtPenaltyAmount::test_WhenUserIsLockedAndDoesNotHaveEnoughBBDebt penalty");
+        // it should allow admin to withdraw the penalty
+        cluster.setRoleForContract(adminAddr, keccak256("HARVEST_TOLP"), true);
+        tolp.harvestPenalties(adminAddr, penalty, SGL_ASSET_ID);
+        assertEq(
+            yieldBox.toAmount(SGL_ASSET_ID, yieldBox.balanceOf(adminAddr, SGL_ASSET_ID), false),
+            penalty,
+            "TOLP_getDebtPenaltyAmount::test_WhenUserIsLockedAndDoesNotHaveEnoughBBDebt penalty harvest"
+        );
+    }
+
+    function _repayDebt(address _user, uint256 _amount) internal {
+        vm.startPrank(_user);
+        // approvals
+        usdoMock.approve(address(yieldBox), type(uint256).max);
+        usdoMock.approve(address(pearlmit), type(uint256).max);
+        yieldBox.setApprovalForAll(address(bigBangEthMarket), true);
+        yieldBox.setApprovalForAll(address(pearlmit), true);
+        pearlmit.approve(
+            1155,
+            address(yieldBox),
+            usdoMockTokenId,
+            address(bigBangEthMarket),
+            type(uint200).max,
+            uint48(block.timestamp)
+        );
+
+        // repay the debt
+        deal(address(usdoMock), _user, _amount);
+        uint256 share = yieldBox.toShare(usdoMockTokenId, _amount, false);
+        yieldBox.depositAsset(usdoMockTokenId, _user, share);
+
+        (BBModule[] memory modules, bytes[] memory calls) = marketHelper.repay(_user, _user, false, _amount);
+        bigBangEthMarket.execute(modules, calls, true);
+        vm.stopPrank();
+    }
+}

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_getDebtPenaltyAmount.tree
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_getDebtPenaltyAmount.tree
@@ -1,0 +1,5 @@
+TOLP_getDebtPenaltyAmount
+└── when user is locked and does not have enough BB debt
+    ├── it should unlock earlier
+    ├── it should apply the penalty
+    └── it should allow admin to withdraw the penalty

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_lock.t.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TOLP_lock.t.sol
@@ -168,7 +168,7 @@ contract TOLP_lock is TolpBaseTest {
 
     modifier depositingCollateralToBigBang(uint128 _ybShares) {
         (_ybShares,) = _boundValues(_ybShares, 0);
-        depositCollateral(aliceAddr, _ybShares);
+        depositBBCollateral(aliceAddr, _ybShares);
         _;
     }
 

--- a/test/unit/options/TapiocaOptionLiquidityProvision/TolpBaseTest.sol
+++ b/test/unit/options/TapiocaOptionLiquidityProvision/TolpBaseTest.sol
@@ -140,7 +140,8 @@ contract TolpBaseTest is UnitBaseTest {
     }
 
     function _createLock(address _user, uint256 _weight, uint128 _lockDuration) internal {
-        depositCollateral(_user, _weight);
+        depositBBCollateral(_user, _weight);
+        depositSGLCollateral(_user, _weight);
 
         (, uint256 shares) = yieldBox.depositAsset(ybAssetIdToftSglEthMarket, _user, _weight);
         vm.startPrank(_user);


### PR DESCRIPTION
fix(`tOLP`):Admin cannot collect totalPenalties because totalPenalties state is not updated properly

https://github.com/Enigma-Dark/Tapioca-Engagement-June/issues/43

patch(`tests`): New `TOLP_getDebtPenaltyAmount`