### PR TITLE
fix(`tOLP`): _canLockWithDebt userLockedUsdo[_user] does not convert yield box share to usdo debt amount

### DIFF
--- a/contracts/options/TapiocaOptionLiquidityProvision.sol
+++ b/contracts/options/TapiocaOptionLiquidityProvision.sol
@@ -239,7 +239,10 @@ contract TapiocaOptionLiquidityProvision is
         usdoAmountFromTolpShare = _getUsdoAmountFromTolpShare(sglAssetIDToAddress[_sglAssetId], _userShare);
 
         totalUserUsdoDebt = totalUserUsdoDebt + (totalUserUsdoDebt * maxDebtBuffer) / 1e4; // total debt + buffer
-        if (usdoAmountFromTolpShare + userLockedUsdo[_user] > totalUserUsdoDebt) {
+        if (
+            usdoAmountFromTolpShare
+                + _getUsdoAmountFromTolpShare(sglAssetIDToAddress[_sglAssetId], userLockedUsdo[_user]) > totalUserUsdoDebt
+        ) {
             return (false, totalUserUsdoDebt, usdoAmountFromTolpShare);
         }
 

--- a/contracts/options/TapiocaOptionLiquidityProvision.sol
+++ b/contracts/options/TapiocaOptionLiquidityProvision.sol
@@ -621,7 +621,7 @@ contract TapiocaOptionLiquidityProvision is
         uint256 amountToLock = _getUsdoAmountFromTolpShare(_singularity, _userShare);
 
         totalUserUsdoDebt = totalUserUsdoDebt + (totalUserUsdoDebt * maxDebtBuffer) / 1e4; // total debt + buffer
-        if (amountToLock + userLockedUsdo[_user] > totalUserUsdoDebt) {
+        if (amountToLock + _getUsdoAmountFromTolpShare(_singularity, userLockedUsdo[_user]) > totalUserUsdoDebt) {
             return false;
         }
         return true;


### PR DESCRIPTION
fix(`tOLP`): _canLockWithDebt userLockedUsdo[_user] does not convert yield box share to usdo debt amount

https://github.com/Enigma-Dark/Tapioca-Engagement-June/issues/50

fix(`tOLP`): canLockWithDebt userLockedUsdo[_user] does not convert yield box share to usdo debt amount

https://github.com/Enigma-Dark/Tapioca-Engagement-June/issues/50